### PR TITLE
Implement followup keys

### DIFF
--- a/Data format (no).md
+++ b/Data format (no).md
@@ -27,6 +27,7 @@ I tillegg til noe informasjon om selve nøkkelen så er det taksa (arter, eller 
 **Subset**: det er mulig å definere subsett til taksa: ett eller flere undernivå av et takson som har forskjellige egenskaper, og som man ønsker at brukeren skal nøkle frem til. For eksempel hann/hunn av samme art (man vil da få spørsmål for å skille mellom de to, også når arten allerede er fastslått).   
 **Morf**: det er mulig å definere morfer av taksa: ett eller flere undernivå av et takson som har forskjellige egenskaper, men som man ikke ønsker at brukeren skal nøkle frem til. For eksempel vanlige/melanistiske individer av samme art (man vil da ikke få spørsmål for å skille mellom de to, det er nok at arten er fastslått).   
 **Sortering**: en sorteringsindeks for visning av arter. Når det er unike tall for alle taksa så styrer denne sorteringen visningen 100%. Taksa uten sortering eller som deler samme sorteringsindeks blir sortert (avløpende) på antall registrerte funn i Artskart.   
+**Oppfølging**: en lenke til en oppfølgingsnøkkel, for å (arts)bestemme nærmere.
 
 ### Egenskaper
 :exclamation:**Spørsmål**: egenskapen, for eksempel “Hva er vingefargen?” eller bare “Vingefarge”.   
@@ -109,6 +110,7 @@ Parametre knyttet til nøkkelens mulige utfall (taksa) får hver sin rad, til h�
 **Subset** | ♂ | ♀ | | | 
 **Media** | 4534 | 7445 | 23423 | 12245 | 7456 
 **Description** | 346773 | 346773 | 345744 | 345744 | 967343
+**Followup** | | | | | /Files/13512
 
 **Name** er en parameter som brukes mens takson-navnet hentes fra artsnavnebasen. Den gjør regnearket også mer oversiktlig.   
 **Taxon** er et id-nummer til et takson i Artsdatabankens system.   
@@ -116,6 +118,7 @@ Parametre knyttet til nøkkelens mulige utfall (taksa) får hver sin rad, til h�
 ***Morfer*** definerer et undernivå av taksonet ved å ha to kolonner for samme takson, men da uten å definere subset. Disse individer har unike egenskaper, men man ønsker ikke at brukeren skal kunne nøkle frem til de. I dette eksempelet vanlig/melanistisk morf av fjellhumla (man vil da ikke få spørsmål for å skille mellom de to, det er nok at det er fastslått at det er fjellhumle).   
 **Media** er et id-nummer som refererer til en bildefil av taksonet i Artsdatabankens system, eller en url som refererer til et bilde et annet sted på nett.   
 **Description** er et id-nummer til en beskrivelse av taksonet i Artsdatabankens system.   
+**Followup** er en peker mot en oppfølgingsnøkkel, som brukeren kan velge å gå videre til for å (arts)bestemme nærmere.
 
 ### Flere eksempler
 Et reelt eksempel med en ikke for kompleks nøkkel:

--- a/Data format (no).md
+++ b/Data format (no).md
@@ -103,14 +103,14 @@ Vingefarge | Rød | TRUE | {vinger} && {6ben} | 3343435 |  | http://www.blablabl
 ### Taksa
 Parametre knyttet til nøkkelens mulige utfall (taksa) får hver sin rad, til høyre for nøkkelinformasjonen og den siste kolonnen med en parameter angående egenskaper .  I sin mest fullstendige form ser feltene slik ut:
 
- | | | | |
- --- | --- | --- | --- | --- | ---
-**Name** | Fjellrev hann | Fjellrev hunn | Fjellhumle vanlig | Fjellhumle melanistisk | Torsk
-**Taxon** | 837700 | 837700 | 634534 | 634534 | 466437
-**Subset** | ♂ | ♀ | | | 
-**Media** | 4534 | 7445 | 23423 | 12245 | 7456 
-**Description** | 346773 | 346773 | 345744 | 345744 | 967343
-**Followup** | | | | | /Files/13512
+| | | | | | |
+| --- | --- | --- | --- | --- | --- |
+|**Name** | Fjellrev hann | Fjellrev hunn | Fjellhumle vanlig | Fjellhumle melanistisk | Torsk |
+|**Taxon** | 837700 | 837700 | 634534 | 634534 | 466437 |
+|**Subset** | ♂ | ♀ | | |  |
+|**Media** | 4534 | 7445 | 23423 | 12245 | 7456 |
+|**Description** | 346773 | 346773 | 345744 | 345744 | 967343 |
+|**Followup** | | | | | /Files/13512 |
 
 **Name** er en parameter som brukes mens takson-navnet hentes fra artsnavnebasen. Den gjør regnearket også mer oversiktlig.   
 **Taxon** er et id-nummer til et takson i Artsdatabankens system.   

--- a/Data format (no).md
+++ b/Data format (no).md
@@ -110,7 +110,7 @@ Parametre knyttet til nøkkelens mulige utfall (taksa) får hver sin rad, til h�
 |**Subset** | ♂ | ♀ | | |  |
 |**Media** | 4534 | 7445 | 23423 | 12245 | 7456 |
 |**Description** | 346773 | 346773 | 345744 | 345744 | 967343 |
-|**Followup** | | | | | /Files/13512 |
+|**Followup** | | | | | /Files/13512&taxa=84373 |
 
 **Name** er en parameter som brukes mens takson-navnet hentes fra artsnavnebasen. Den gjør regnearket også mer oversiktlig.   
 **Taxon** er et id-nummer til et takson i Artsdatabankens system.   
@@ -118,7 +118,7 @@ Parametre knyttet til nøkkelens mulige utfall (taksa) får hver sin rad, til h�
 ***Morfer*** definerer et undernivå av taksonet ved å ha to kolonner for samme takson, men da uten å definere subset. Disse individer har unike egenskaper, men man ønsker ikke at brukeren skal kunne nøkle frem til de. I dette eksempelet vanlig/melanistisk morf av fjellhumla (man vil da ikke få spørsmål for å skille mellom de to, det er nok at det er fastslått at det er fjellhumle).   
 **Media** er et id-nummer som refererer til en bildefil av taksonet i Artsdatabankens system, eller en url som refererer til et bilde et annet sted på nett.   
 **Description** er et id-nummer til en beskrivelse av taksonet i Artsdatabankens system.   
-**Followup** er en peker mot en oppfølgingsnøkkel, som brukeren kan velge å gå videre til for å (arts)bestemme nærmere.
+**Followup** er en url til en oppfølgingsnøkkel, som brukeren kan velge å gå videre til for å (arts)bestemme nærmere. Ved å oppgi en kommaseparert liste over takson-id'er i url'en som *&taxa=x,y* kan det spesifiseres at kun undertaksa av taksa x og y er aktuelle. Det er vanligvis en god idé å oppgi id'en til det gjeldende resultatet når man videresender til en annen nøkkel, siden den kan omfatte en større gruppe. 
 
 ### Flere eksempler
 Et reelt eksempel med en ikke for kompleks nøkkel:

--- a/app/viewmodels/key.js
+++ b/app/viewmodels/key.js
@@ -182,7 +182,8 @@ define(['durandal/app', 'knockout', 'plugins/http', 'plugins/router', 'underscor
                     taxonIdRow = taxonHeaders.indexOf("Taxon"),
                     taxonMediaRow = taxonHeaders.indexOf("Media"),
                     taxonDescriptionRow = taxonHeaders.indexOf("Description"),
-                    taxonSortRow = taxonHeaders.indexOf("Sort");
+                    taxonSortRow = taxonHeaders.indexOf("Sort"),
+                    taxonFollowupRow = taxonHeaders.indexOf("Followup");
 
                 for (var i = headerColumn + 1; i < array[0].length; i++) {
                     taxa.push({
@@ -193,6 +194,7 @@ define(['durandal/app', 'knockout', 'plugins/http', 'plugins/router', 'underscor
                         media: (taxonMediaRow > -1 && array[taxonMediaRow][i] ? array[taxonMediaRow][i] : null),
                         sort: (taxonSortRow > -1 && array[taxonSortRow][i] ? array[taxonSortRow][i] : null),
                         description: (taxonDescriptionRow > -1 && array[taxonDescriptionRow][i] ? array[taxonDescriptionRow][i] : null),
+                        followup: (taxonFollowupRow > -1 && array[taxonFollowupRow][i] ? array[taxonFollowupRow][i] : null),
                         taxonObject: null,
                         stateValues: []
                     });

--- a/app/viewmodels/key.js
+++ b/app/viewmodels/key.js
@@ -284,12 +284,9 @@ define(['durandal/app', 'knockout', 'plugins/http', 'plugins/router', 'underscor
                     urlTaxa = getUrlParameter('taxa');
                 
                 if(urlTaxa)
-					urlTaxa = urlTaxa.split(',').map(function(x){return +x;});
-				else
-					urlTaxa = [];
-                
-                
-                 
+                    urlTaxa = urlTaxa.split(',').map(function(x){return +x;});
+                else
+                    urlTaxa = [];
 
                 _.each(taxa, function (taxon) {
                     taxon.vernacular = taxon.name || "Loading...";
@@ -358,7 +355,6 @@ define(['durandal/app', 'knockout', 'plugins/http', 'plugins/router', 'underscor
                             });
                         });
                     }));
-
 
                     //~ fetch abundances from the API
                     _.each(_.uniq(taxa, function (taxon) {
@@ -437,7 +433,6 @@ define(['durandal/app', 'knockout', 'plugins/http', 'plugins/router', 'underscor
                                 })).status() === 1;
                         }
                     });
-
 
                     _.each(character.states, function (state) {
                         state.zeroes = ko.pureComputed(function () {

--- a/app/views/key.html
+++ b/app/views/key.html
@@ -24,7 +24,13 @@
 					<h2 data-bind="text: key.taxaList()[0].vernacular"></h2>
 					<h4><i data-bind="text: key.taxaList()[0].scientific"></i> <span style="margin-left: 15px;" class="clickable glyphicon glyphicon-link" data-bind="visible: key.taxaList()[0].description, click: $root.showDescription;"></span></h4>
 					<h5 data-bind="text: key.taxaList()[0].subset"></h5>
-				</span> 
+				</span>
+				
+				<span data-bind="visible: key.taxaList()[0].followup">
+					<a data-bind="attr: {href : '.?csv=' + key.taxaList()[0].followup}">Artsbestem videre</a>
+				</span>
+				
+				
 			<!-- /ko -->
 			<!-- ko if: key.taxaList()[0] && key.taxaList()[1] -->
 				<h4>Nøkkelen kan ikke bestemme resultatet nærmere. Disse mulige utfall gjenstår:</h4>


### PR DESCRIPTION
Followup is now a dataset parameter, and a list of parent taxa can be provided in the url to pre-filter relevant results.
